### PR TITLE
Fixed bug: data corruption on multiple open tabs/clients

### DIFF
--- a/routes/DesignAutomation.js
+++ b/routes/DesignAutomation.js
@@ -618,7 +618,7 @@ router.post('/forge/callback/designautomation', async /*OnCallback*/ (req, res) 
         http.get(
             bodyJson.reportUrl,
             response => {
-                //socketIO.emit('onComplete', response);
+                //socketIO.to(req.query.id).emit('onComplete', response);
                 response.setEncoding('utf8');
                 let rawData = '';
                 response.on('data', (chunk) => {
@@ -629,7 +629,7 @@ router.post('/forge/callback/designautomation', async /*OnCallback*/ (req, res) 
                 });
             }
         );
-        //socketIO.emit('downloadReport', bodyJson.reportUrl);
+        //socketIO.to(req.query.id).emit('downloadReport', bodyJson.reportUrl);
 
         const objectsApi = new ForgeAPI.ObjectsApi();
         const bucketKey = Utils.NickName.toLowerCase() + '-designautomation';
@@ -646,10 +646,10 @@ router.post('/forge/callback/designautomation', async /*OnCallback*/ (req, res) 
                 },
                     req.oauth_client, req.oauth_token
                 );
-                socketIO.emit('downloadResult', signedUrl.body.signedUrl);
+                socketIO.to(req.query.id).emit('downloadResult', signedUrl.body.signedUrl);
             } catch (ex) {
                 console.error(ex);
-                socketIO.emit('onComplete', 'Failed to create presigned URL for outputFile.\nYour outputFile is available in your OSS bucket.');
+                socketIO.to(req.query.id).emit('onComplete', 'Failed to create presigned URL for outputFile.\nYour outputFile is available in your OSS bucket.');
             }
         }
 


### PR DESCRIPTION
A small bug which would transmit `downloadResult` and `onComplete` to all open socket clients, as the `to` param in socketIO was missing.
Now emits response to the right client only.
