### PR TITLE
fix design automation get engines method and update

### DIFF
--- a/forgesample/Controllers/DesignAutomationController.cs
+++ b/forgesample/Controllers/DesignAutomationController.cs
@@ -218,7 +218,7 @@ namespace forgeSample.Controllers
             foreach (KeyValuePair<string, string> x in newAppVersion.UploadParameters.FormData) request.AddParameter(x.Key, x.Value);
             request.AddFile("file", packageZipPath);
             request.AddHeader("Cache-Control", "no-cache");
-            await uploadClient.ExecuteTaskAsync(request);
+            await uploadClient.ExecuteAsync(request);
 
             return Ok(new { AppBundle = qualifiedAppBundleId, Version = newAppVersion.Version });
         }
@@ -358,12 +358,19 @@ namespace forgeSample.Controllers
         public async Task<List<string>> GetAvailableEngines()
         {
             dynamic oauth = await OAuthController.GetInternalAsync();
-
+            List<string> allEngines = new List<string>();
             // define Engines API
-            Page<string> engines = await _designAutomation.GetEnginesAsync();
-            engines.Data.Sort();
-
-            return engines.Data; // return list of engines
+            string paginationToken = null;
+            while (true)
+            {
+                Page<string> engines = await _designAutomation.GetEnginesAsync(paginationToken);
+                allEngines.AddRange(engines.Data);
+                if (engines.PaginationToken == null)
+                    break;
+                paginationToken = engines.PaginationToken;
+            } 
+            allEngines.Sort();
+            return allEngines; // return list of engines
         }
 
         /// <summary>

--- a/forgesample/README.md
+++ b/forgesample/README.md
@@ -1,7 +1,7 @@
 # learn.forge.designautomation - ASP.NET Core
 
 ![Platforms](https://img.shields.io/badge/platform-Windows|MacOS-lightgray.svg)
-![.NET](https://img.shields.io/badge/.NET%20Core-2.1-blue.svg)
+![.NET](https://img.shields.io/badge/.NET%20Core-3.1-blue.svg)
 [![License](http://img.shields.io/:license-MIT-blue.svg)](http://opensource.org/licenses/MIT)
 
 [![oAuth2](https://img.shields.io/badge/oAuth2-v1-green.svg)](http://developer.autodesk.com/)
@@ -80,7 +80,7 @@ Documentation:
 
 Other APIs:
 
-- [.NET Core SignalR](https://docs.microsoft.com/en-us/aspnet/core/signalr/introduction?view=aspnetcore-2.2)
+- [.NET Core SignalR](https://docs.microsoft.com/en-us/aspnet/core/signalr/introduction?view=aspnetcore-3.1)
 
 ### Tips & Tricks
 

--- a/forgesample/Startup.cs
+++ b/forgesample/Startup.cs
@@ -13,7 +13,9 @@ namespace forgeSample
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddMvc(options => options.EnableEndpointRouting = false).SetCompatibilityVersion(CompatibilityVersion.Version_3_0).AddNewtonsoftJson();
-            services.AddSignalR();
+            services.AddSignalR().AddNewtonsoftJsonProtocol(opt=> {
+                opt.PayloadSerializerSettings.ReferenceLoopHandling = Newtonsoft.Json.ReferenceLoopHandling.Ignore;
+            });
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/forgesample/forgesample.csproj
+++ b/forgesample/forgesample.csproj
@@ -1,14 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <Folder Include="wwwroot\" />
         <Folder Include="wwwroot\bundles\" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Autodesk.Forge" Version="1.6.0" />
-        <PackageReference Include="Autodesk.Forge.DesignAutomation" Version="3.0.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0" />
+        <PackageReference Include="Autodesk.Forge" Version="1.8.0" />
+        <PackageReference Include="Autodesk.Forge.DesignAutomation" Version="3.0.2" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.10" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="3.1.10" />
     </ItemGroup>
 </Project>

--- a/forgesample/wwwroot/index.html
+++ b/forgesample/wwwroot/index.html
@@ -10,7 +10,7 @@
     <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js"></script>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/css/bootstrap.min.css">
     <!-- .NET SignalR -->
-    <script src="//unpkg.com/@aspnet/signalr@1.1.0/dist/browser/signalr.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/microsoft-signalr/3.1.7/signalr.min.js"></script>
     <!-- Files for this project -->
     <script src="/js/ForgeDesignAutomation.js"></script>
 </head>


### PR DESCRIPTION
Ignored referenceloop (as mentioned here) on Startup.cs:
```
services.AddSignalR().AddNewtonsoftJsonProtocol(opt=> {
    opt.PayloadSerializerSettings.ReferenceLoopHandling = Newtonsoft.Json.ReferenceLoopHandling.Ignore;
});
```
Updated badge and reference on README.md:
```
![.NET](https://img.shields.io/badge/.NET%20Core-3.1-blue.svg)
[.NET Core SignalR](https://docs.microsoft.com/en-us/aspnet/core/signalr/introduction?view=aspnetcore-3.1)
```
Package updated, as mentioned [here](https://docs.microsoft.com/pt-br/aspnet/core/signalr/javascript-client?view=aspnetcore-3.1#use-a-content-delivery-network-cdn) on index.html:
```
<script src="https://cdnjs.cloudflare.com/ajax/libs/microsoft-signalr/3.1.7/signalr.min.js"></script>
```
Updated packages and added package to change to Newtonsoft on signalR on forgeSample.csproj:
```
<PackageReference Include="Autodesk.Forge" Version="1.8.0" />
<PackageReference Include="Autodesk.Forge.DesignAutomation" Version="3.0.2" />
<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.10" />
<PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="3.1.10" />
```
GetAvailableEngines changed to include pagination on DesignAutomationController.cs:
```
dynamic oauth = await OAuthController.GetInternalAsync();

List<string> allEngines = new List<string>();

// define Engines API
string paginationToken = null;
while (true)
{
    Page<string> engines = await _designAutomation.GetEnginesAsync(paginationToken);
    allEngines.AddRange(engines.Data);
    if (engines.PaginationToken == null)
        break;
    paginationToken = engines.PaginationToken;
} 
allEngines.Sort();
return allEngines; // return list of engines
```